### PR TITLE
Add cat following mode

### DIFF
--- a/frontend/core.py
+++ b/frontend/core.py
@@ -139,7 +139,7 @@ class Core:
         self.parser.add_argument(
             "--num-points",
             type=int,
-            default=5,
+            default=500,
             help="Number of points",
         )
         self.parser.add_argument(

--- a/frontend/core.py
+++ b/frontend/core.py
@@ -139,7 +139,7 @@ class Core:
         self.parser.add_argument(
             "--num-points",
             type=int,
-            default=500,
+            default=5,
             help="Number of points",
         )
         self.parser.add_argument(

--- a/frontend/ui.py
+++ b/frontend/ui.py
@@ -69,13 +69,11 @@ uniform int highlightedIndex; // Index of the highlighted point
 
 void main() {
     gl_PointSize = pointRadius * 2.0 * zoom;
-
     gl_Position = vec4((position + panOffset) * zoom, 0.0, 1.0); // Output requires vec4(float)
     fragState = state; // Pass state to fragment shader
     fragIndex = index;
 }
 """
-# (position + panOffset) * zoom
 # Fragment shader code to sample from texture or set color
 fragment_shader_code = """
 #version 410 core
@@ -344,7 +342,6 @@ class MovingPointsCanvas(QOpenGLWidget):
         self.shader_program["zoom"].value = float(self.zoom_factor)
         self.shader_program["panOffset"].value = tuple(self.pan_offset)
         self.shader_program["useTexture"].value = self.use_texture
-        
         self.shader_program["highlightedIndex"].value = (
             self.followed_cat_id if self.followed_cat_id is not None else -1
         )
@@ -354,7 +351,6 @@ class MovingPointsCanvas(QOpenGLWidget):
             self.texture.use(0)
             self.shader_program["pointTexture"].value = 0
 
-
         if self.followed_cat_id is not None:
             followed_cat_pos = self.points[self.followed_cat_id]
             distances = np.linalg.norm(self.points - followed_cat_pos, axis=1)
@@ -363,12 +359,10 @@ class MovingPointsCanvas(QOpenGLWidget):
             visible_states = self.states[visible_indices]
         else:
             visible_points = self.points
-            visible_states = self.states
-        
+            visible_states = self.states 
 
         self.vbo.write(visible_points.astype("f4").tobytes())
         self.state_buffer.write(visible_states.astype("i4").tobytes())
-
         # Render the points
         self.update_buffers()
         self.vao.render(moderngl.POINTS, vertices=self.num_points)

--- a/frontend/ui.py
+++ b/frontend/ui.py
@@ -467,7 +467,7 @@ class MovingPointsCanvas(QOpenGLWidget):
     def keyPressEvent(self, event):
         if event is None:
             return
-        if event.key() == Qt.Key.Key_F:
+        if event.nativeVirtualKey() == 0x46: # 0x46 - is the key code for F
             self.stop_following()
             self.update()
 

--- a/frontend/ui.py
+++ b/frontend/ui.py
@@ -65,7 +65,7 @@ flat out int fragIndex;
 uniform float pointRadius;
 uniform float zoom;
 uniform vec2 panOffset;
-uniform int highlightedIndex; // Индекс выделенной точки
+uniform int highlightedIndex; // Index of the highlighted point
 
 void main() {
     gl_PointSize = pointRadius * 2.0 * zoom;
@@ -84,7 +84,7 @@ flat in int fragIndex;
 flat in int fragState; // State passed from vertex shader
 uniform sampler2D pointTexture;
 uniform bool useTexture;
-uniform int highlightedIndex;  // Индекс выделенной точки
+uniform int highlightedIndex;  // Index of follo
 out vec4 fragColor;
 
 float star(vec2 p, float r, int n, float m) {
@@ -120,10 +120,9 @@ void main() {
         }
 
         if (fragIndex == highlightedIndex) {
-            // Создаем звезду
-            float s = star(coord * 1.5, 0.3, 5, 3.0); // Параметры: позиция, размер, количество лучей, острота
-            if (s < 0.0) { // Если точка внутри звезды
-                fragColor = vec4(1.0, 1.0, 1.0, 1.0); // Белая звезда
+            float s = star(coord * 1.5, 0.3, 5, 3.0);
+            if (s < 0.0) {
+                fragColor = vec4(1.0, 1.0, 1.0, 1.0); // White star
             }
         }
     }
@@ -211,11 +210,10 @@ class MovingPointsCanvas(QOpenGLWidget):
         self.timer.start(1)
         self.timer.timeout.connect(self.update_positions)
 
-        # 
         self.followed_cat_id : int | None = None
         self.follow_radius : float = 0.5
 
-        self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)  # Виджет получает фокус при клике
+        self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)  # Widget receives focus when clicked
 
     def update_deltas(self):
         self.deltas = self.core.generate_deltas(
@@ -265,18 +263,16 @@ class MovingPointsCanvas(QOpenGLWidget):
         interpolation_speed = 1.0 / self.FPS
         self.points += self.deltas * interpolation_speed
 
-        # Если включена слежка, центрируем камеру на выбранном коте
+        # If tracking is enabled, center the camera on the selected cat
         if self.followed_cat_id is not None:
             followed_cat_pos  = self.points[self.followed_cat_id]
 
-            # Определяем целевое положение камеры с небольшим отставанием
-            smoothness = 0.1  # Коэффициент плавности (меньше = плавнее)
+            smoothness = 0.1  # Smoothness coefficient
             
-            # Вычисляем желаемое положение камеры
             target_x = -followed_cat_pos[0]
             target_y = -followed_cat_pos[1]
             
-            # Плавно перемещаем камеру к целевой позиции
+            # Smoothly move camera to target position
             self.pan_offset[0] = self.pan_offset[0] * (1 - smoothness) + target_x * smoothness
             self.pan_offset[1] = self.pan_offset[1] * (1 - smoothness) + target_y * smoothness
 
@@ -318,7 +314,7 @@ class MovingPointsCanvas(QOpenGLWidget):
         self.state_buffer = self.ctx.buffer(self.states.astype("i4").tobytes())
 
         indices = np.arange(len(self.points), dtype=np.int32)
-        self.index_buffer = self.ctx.buffer(indices.astype("i4").tobytes())  # Индексы
+        self.index_buffer = self.ctx.buffer(indices.astype("i4").tobytes())
 
         # Create Vertex Array Object (VAO)
         self.vao = self.ctx.vertex_array(
@@ -535,7 +531,7 @@ class MainWindow(QMainWindow):
         main_widget.setLayout(control_layout)
         self.setCentralWidget(main_widget)
 
-        self.canvas.setFocus()  # Установить фокус на canvas при запуске
+        self.canvas.setFocus()  # Set focus on canvas at startup
 
     def update_num_points(self, value: int):
         self.canvas.update_num_points(value)

--- a/frontend/ui.py
+++ b/frontend/ui.py
@@ -55,6 +55,7 @@ class Core(Protocol):
 
 # Vertex shader code with zoom and pan transformations
 
+
 vertex_shader_code = """
 #version 410 core
 
@@ -76,6 +77,7 @@ void main() {
 }
 """
 # Fragment shader code to sample from texture or set color
+
 
 fragment_shader_code = """
 #version 410 core
@@ -467,7 +469,7 @@ class MovingPointsCanvas(QOpenGLWidget):
     def keyPressEvent(self, event):
         if event is None:
             return
-        if event.nativeVirtualKey() == 0x46: # 0x46 - is the key code for F
+        if event.nativeVirtualKey() == 0x46:  # 0x46 - is the key code for F
             self.stop_following()
             self.update()
 

--- a/frontend/ui.py
+++ b/frontend/ui.py
@@ -87,6 +87,18 @@ uniform bool useTexture;
 uniform int highlightedIndex;  // Индекс выделенной точки
 out vec4 fragColor;
 
+float star(vec2 p, float r, int n, float m) {
+    float an = 3.141593 / float(n);
+    float en = 3.141593 / m;
+    vec2 acs = vec2(cos(an), sin(an));
+    vec2 ecs = vec2(cos(en), sin(en));
+    float bn = mod(atan(p.x, p.y), 2.0 * an) - an;
+    p = length(p) * vec2(cos(bn), abs(sin(bn)));
+    p -= r * acs;
+    p += ecs * clamp(-dot(p, ecs), 0.0, r * acs.y / ecs.y);
+    return length(p) * sign(p.x);
+}
+
 void main() {
     if (useTexture) {
         vec2 coord = gl_PointCoord;
@@ -108,7 +120,11 @@ void main() {
         }
 
         if (fragIndex == highlightedIndex) {
-            fragColor = fragColor * 0.7;
+            // Создаем звезду
+            float s = star(coord * 1.5, 0.3, 5, 3.0); // Параметры: позиция, размер, количество лучей, острота
+            if (s < 0.0) { // Если точка внутри звезды
+                fragColor = vec4(1.0, 1.0, 1.0, 1.0); // Белая звезда
+            }
         }
     }
 }

--- a/frontend/ui.py
+++ b/frontend/ui.py
@@ -457,7 +457,7 @@ class MovingPointsCanvas(QOpenGLWidget):
         ) / self.zoom_factor - self.pan_offset[1]
 
         distances = np.linalg.norm(self.points - np.array([world_x, -world_y]), axis=1)
-        nearest_cat_id = np.argmin(distances)
+        nearest_cat_id = int(np.argmin(distances))
 
         if distances[nearest_cat_id] < self.follow_radius:
             self.followed_cat_id = nearest_cat_id


### PR DESCRIPTION
Теперь появляется возможность следить за определенным котом на карте: по двойному клику мыши для слежки будет выбран ближайший кот. В этом режиме камера будет перемещаться за этим котом и можно будет видеть только его ближайших соседей. Преследуемый кот будет отмечен белой звездой. Для выхода из данного режима необходимо нажать 'F' - обзор вернется в предыдущее состояние.
Стоит также отметить, что в данном режиме отключена возможность изменения количества котов на карте